### PR TITLE
Move timestamps to CSS div:before statements

### DIFF
--- a/droppdf/apps/_templates/youtube.html
+++ b/droppdf/apps/_templates/youtube.html
@@ -190,9 +190,19 @@
             padding-bottom: .5em;
         }
 
+        .sub-text:before {
+            width: 2em;
+            display: inline-block;
+            border-right: 1px solid black;
+            margin-right: 0.5em;
+        }
+
         .sub-text {
             flex: 1;
             flex-basis: 0;
+            padding-left: 6.5em;
+            text-indent: -2.6em;
+            margin-right: 3em;
         }
 
         .sub-label {
@@ -262,6 +272,8 @@
             width: 100%;
             height: 100%;
         }
+
+        {% for sub in transcript %}div.sub-text div.line{{ loop.index }}:before {content: "{{ sub.start_display }}";}
 
         @media (max-width: 992px) {
             body {
@@ -432,11 +444,7 @@
                     <div id="substart-text" class="sub-text italic">Select text to annotate, Click play in YouTube to begin</div>
                 </div>
                 {% for sub in transcript %}
-                <div class="sub" dir="ltr">
-                    <div class="sub-time">
-                        {{ sub.start_display }}
-                    </div>
-                    <div class="sub-text" onclick="updatePlayerTime({{ sub.start }});">
+                    <div class="sub-text line{{ loop.index }}" onclick="updatePlayerTime({{ sub.start }});" dir="ltr">
                         {{ sub.text }}
                     </div>
                 </div>


### PR DESCRIPTION
Addresses https://github.com/dwhly-proj/droppdf/issues/129

If @seconddayout is like me, the issue is with the YouTube video transcripts. Although it looks like one can select across &lt;div&gt;s...

<img width="494" alt="image" src="https://user-images.githubusercontent.com/152960/211171043-379ac62c-c008-4a19-b4a4-c64a9b4db8a3.png">

...when Hypothesis grabs the text, it only gets the part in the first &lt;div&gt;:

<img width="1383" alt="image" src="https://user-images.githubusercontent.com/152960/211171092-f7e15757-a214-4b4c-a2b6-28f0f064295e.png">

I ran into this same sort of problem when I was creating an equivalent to _droppdf_ for podcasts (see [unchecked-transcript](https://github.com/dltj/unchecked-transcript)). To solve the problem, I put the timestamp into a CSS `:before` declaration. See [this example](https://media.dltj.org/unchecked-transcript/20220928T194120-99-_Invisible--Search_and_Ye_Might_Find/index.html) for what it looks like in practice—notably the first Hypothesis annotation that crosses three &lt;div&gt;s.

This pull request is my best guess at how this solution would work with droppdf. Unfortunately, I couldn't get all of the droppdf prerequisites to install on my machine, so I wasn't able to do an end-to-end test of the code changes.